### PR TITLE
Fixes Firebase Hosting Weekly deploy.

### DIFF
--- a/.github/workflows/deploy-firebase-hosting-prod.yml
+++ b/.github/workflows/deploy-firebase-hosting-prod.yml
@@ -3,7 +3,7 @@ on:
   schedule:
       # * is a special character in YAML so you have to quote this string
       # Deploy Mondays at 8AM PT. Note that GitHub Actions cron timespec is in UTC.
-      - cron:  '* 15 * * 1' 
+      - cron:  '0 15 * * 1' 
       
 jobs:
   deploy:


### PR DESCRIPTION
Error in cron timespec made it run every minute of the 15th hour on Mondays. Corrected this to be only the 15th hour on Mondays.