### PR TITLE
DX: Adds a Github action to nag stale PRs.

### DIFF
--- a/.github/workflows/nag-on-stale-pr.yml
+++ b/.github/workflows/nag-on-stale-pr.yml
@@ -1,0 +1,19 @@
+name: "Nag PR when PR is Stale 3 days"
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.REPO_OWNER_GITHUB_TOKEN }}
+        skip-stale-issue-message: true
+        # We don't want to auto-close PRs but we do want to nag the author.
+        days-before-stale: 1
+        days-before-close: 365
+        remove-stale-when-updated: true
+        stale-pr-message: 'Friendly ping. Either a review is pending or changes are requested'
+        stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
This Github action periodically checks PRs for activity and posts a
friendly message to remind reviewers and authors to update/merge/close
the PR.

The check will only consider PRs stale when at least 3 days pass with no
updates.