### PR TITLE
Fixed typo in Prettier Action

### DIFF
--- a/.github/workflows/format-on-pr.yml
+++ b/.github/workflows/format-on-pr.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           # Make sure the actual branch is checked out when running on pull requests
           ref: ${{ github.head_ref }}
-          fetch_depth: 0
+          fetch-depth: 0
 
       - name: Prettify code
         uses: creyD/prettier_action@v3.1


### PR DESCRIPTION
There was a typo on one of the arguments. Previously it was `fetch_depth` whereas it should be `fetch-depth` (underscore vs hyphen).