### PR TITLE
Adds Firestore Excercise.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1196,6 +1196,12 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -1554,6 +1560,20 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -1578,6 +1598,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -2167,6 +2193,15 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -2455,6 +2490,12 @@
         "optionator": "^0.8.1",
         "source-map": "~0.6.1"
       }
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.1",
@@ -3149,6 +3190,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stream": {
@@ -5025,6 +5072,12 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -6162,6 +6215,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "start:local": "firebase serve -P dev --only hosting",
     "stop:firebase": "lsof -ti :5000-5003 | xargs --no-run-if-empty kill",
     "pretest": "npm run stop:firebase",
-    "test": "env FIRESTORE_EMULATOR_HOST=\"localhost:5003\" firebase emulators:exec \"mocha test --exit\""
+    "test": "env FIRESTORE_EMULATOR_HOST=localhost:5002 firebase emulators:exec \"mocha --recursive test/**/*.js --require esm --exit\""
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^1.1.9",
+    "chai": "^4.2.0",
+    "esm": "^3.2.25",
     "firebase": "^7.13.1",
     "firebase-tools": "^9.2.2",
     "mocha": "^8.2.1",

--- a/test/ex01/README.md
+++ b/test/ex01/README.md
@@ -1,0 +1,69 @@
+# Excercise 01: Fun with Firestore
+
+## Overview
+
+This folder contains excercises aimed at learning how to work with the
+Firestore Javascript SDK. When you are don you will know:
+
+- How to use the main Firestore objects: Collections, Documents, Data.
+- How to write code that performs basic firestore operations such as
+  reading/writing Collections (and subcollections), Documents, and Data
+- How to write tests for your code using the Mochajs testing framework.
+
+## Excercise Details
+
+Your code must do all of the following tasks. We've created a test suite that
+will check that each tasks is done.
+
+1.  Create a top level collection called `exercise01TopLevelCollection` which
+    contains a Document called `testDocument`, the document contains the
+    following data:
+
+    1. `authorName`: String, The name of the implementor.
+
+2.  Add document called `stepsCompleted` to your top level collection. It
+    must contain the following data:
+
+    1. `createdATopLevelCollection`: Boolean, Set when you create your
+       top-level collection
+    2. `addADocumentInTopLevelCollection`: Boolean, Set when you add datum
+       (see above) to your top-level collection
+    3. `createdResearchItemsSubCollection`: Boolean, Set when you create
+       your `researchItemsCollection` sub collection
+    4. `addedAllResearchDocuments`: Boolean, Set when you all documents
+       to the `researchItemsCollection` sub collection
+
+3.  Add a subcollection to your top level collection. This sub-collection
+    should be named `researchItemsCollection`. It should contain 9 research items
+    (see the [Research Document](#research-items) for details). For each item,
+    create a Firestore document with the following data:
+    1. `title`: String, The title of the document
+    2. `category`: String, Must be one of: `GIT`, `WebRTC`, or `Firebase`
+    3. `url`: String, The URL of the document
+    4. `summary`: String, A 30 word summary of the document you read.
+    5. `date`: String, The date you read the document
+
+### Research Items
+
+An important part of engineering is research. We've put together a collection
+of reading materials you should read to ramp up on coding with Firestore and
+WebRTC. For this excercise, you'll select 9 articles to read and create short
+summary for each (in your own words). You'll select 3 articles for each of
+the following topics:
+
+- Git
+- WebRTC
+- Firebase
+
+At least 2 documents must be from the recommened reading list (check the deep
+dive slides). The last article will be one you find on your own.
+
+## Getting Started
+
+TODO: Create `template.js` from `solution.js`
+
+1. Make a copy of the `template.js` template in this directory.
+   Give it a unique name such as `joe_ex01.test.js`
+2. Update your file to implement the required functionality.
+3. Update the `unit.test.js` to import your module
+4. Run the tests: `npm tests`

--- a/test/ex01/constants.js
+++ b/test/ex01/constants.js
@@ -1,0 +1,9 @@
+/**
+ * Contains constants used by implementations and tests.
+ */
+export const TOP_LEVEL_COLLECTION_NAME = "exercise01TopLevelCollection";
+export const TEST_DOCUMENT_NAME = "testDocument";
+export const COMPLETED_STEPS_DOC_NAME = "completedStepsDocument";
+export const RESEARCH_ITEMS_COLLECTION_NAME = "researchItemsCollection";
+export const PROJECT_ID = "mellychat-dev";
+export const FIRESTORE_EMULATOR_PORT = 5002;

--- a/test/ex01/solution.js
+++ b/test/ex01/solution.js
@@ -1,0 +1,97 @@
+/*
+ * DELETE ME TEXT: Make a copy, do not modify.
+ * Implements Excercise 01: Fun with Firestore SDK.
+ * @Date: 2021/01/DD
+ */
+import firebase from "firebase/app";
+import "firebase/firestore";
+
+import {
+  TOP_LEVEL_COLLECTION_NAME,
+  TEST_DOCUMENT_NAME,
+  COMPLETED_STEPS_DOC_NAME,
+  RESEARCH_ITEMS_COLLECTION_NAME,
+} from "./constants.js";
+
+/**
+ * Creates a sub collection in the given top level collection.
+ *
+ * The create sub collection which stores documents that contain info about
+ * research documents we've read. Also updates the steps completed collection
+ * to reflect progress.
+ *
+ * @param {firestore.Firestore} db The firestore instance.
+ */
+function createResearchItemsCollection(db) {
+  // TODO: Create a collection inside the top level collection.
+  // TODO: Update the steps completed collection.
+}
+
+/**
+ * Adds the required research items into the collection.
+ *
+ * Also updates the steps completed collection to refelect progress.
+ *
+ * @param {firestore.Firestore} db The firestore instance.
+ */
+function allAllResearchItems(db) {
+  // TODO: Add 3 git documents
+  // TODO: Add 3 webRTC documents
+  // TODO: Add 3 firebase documents
+}
+
+/**
+ * Creates a document in the given top level collection.
+ *
+ * Also add booleans which track progress on the exercise.
+ *
+ * @param {firestore.Firestore} db The firestore instance.
+ */
+async function createStepsCompletedDoc(db) {
+  await db
+    .collection(TOP_LEVEL_COLLECTION_NAME)
+    .doc(COMPLETED_STEPS_DOC_NAME)
+    .set({
+      createdATopLevelCollection: true,
+      addADocumentInTopLevelCollection: true,
+      createdResearchItemsSubCollection: false,
+      addedAllResearchDocuments: false,
+    });
+
+  console.log(
+    `Added doc named ${COMPLETED_STEPS_DOC_NAME} in ${topLevelCollection.id}`
+  );
+}
+
+/**
+ * Create a top-level collection with the given name.
+ *
+ * @param {firestore.Firestore} db The firestore instance.
+ */
+async function createTopLevelCollection(db) {
+  const name = "CodeNext";
+  collectionRef = db
+    .collection(TOP_LEVEL_COLLECTION_NAME)
+    .doc(TEST_DOCUMENT_NAME)
+    .set({ authorName: name });
+
+  console.log(
+    `Created doc ${TEST_DOCUMENT_NAME} in collection ${collection}. Set authorName to "${name}"`
+  );
+}
+
+/**
+ * Implements all required functionality.
+ *
+ * @param {firebase.firestore.Firestore} db The firestore instance.
+ */
+export function Run(db) {
+  const topLevelCollection = createTopLevelCollection(db);
+
+  const stepsCompletedDoc = createStepsCompletedDoc(db);
+  const researchItemsCollection = createResearchItemsCollection(
+    topLevelCollection,
+    stepsCompletedDoc
+  );
+  allAllResearchItems(researchItemsCollection, stepsCompletedDoc);
+}

--- a/test/ex01/template.js
+++ b/test/ex01/template.js
@@ -1,0 +1,113 @@
+/*
+ * DELETE ME TEXT: Make a copy, do not modify.
+ * Implements Excercise 01: Fun with Firestore SDK.
+ * @Author: Your Name
+ * @Date: 2021/01/DD
+ */
+import firebase, { firestore } from "firebase/app";
+import "firebase/firestore";
+
+import {
+  TOP_LEVEL_COLLECTION_NAME,
+  TEST_DOCUMENT_NAME,
+  COMPLETED_STEPS_DOC_NAME,
+  RESEARCH_ITEMS_COLLECTION_NAME,
+} from "./constants";
+
+/**
+ * Creates a sub collection in the given top level collection.
+ *
+ * The create sub collection stores documents that contain info about research
+ * documents we've read. Also updates the steps completed collection to reflect
+ * progress.
+ *
+ * @param {firestore.CollectionReference} topLevelCollection The reference to
+ * the top level collection.
+ * @param {firestore.CollectionReference} stepsCompletedCollection The
+ * reference to the collection used to track progress.
+ */
+function createResearchItemsCollection(
+  topLevelCollection,
+  stepsCompletedCollection
+) {
+  throw "NotImplementedError: Implement Me!";
+  // 1. Create a collection inside the top level collection.
+
+  // 2. Update the steps completed collection
+}
+
+/**
+ * Adds the required research items into the collection.
+ *
+ * Also updates the steps completed collection to refelect progress.
+ *
+ * @param {firestore.CollectionReference} researchItemsCollection The reference
+ * to the collection where research items will be added.
+ * @param {firestore.CollectionReference} stepsCompletedCollection The
+ * reference to the collection used to track progress.
+ */
+function allAllResearchItems(
+  researchItemsCollection,
+  stepsCompletedCollection
+) {
+  throw "NotImplementedError: Implement Me!";
+
+  console.log(
+    `Added ${documentsAdded} to the ${RESEARCH_ITEMS_COLLECTION_NAME}`
+  );
+}
+
+/**
+ * Creates a subcollection in the given top level collection.
+ *
+ * Also add booleans which track progress on the exercise.
+ *
+ * @param {firestore.CollectionReference} topLevelCollection a reference to
+ *  the top level collection.
+ * @returns {firestore.CollectionReference} The reference to the created
+ *  collection.
+ */
+function createStepsCompletedCollection(topLevelCollection) {
+  throw "NotImplementedError: Implement Me!";
+  // 1. Create the sub collection
+
+  // 2. Populate it with required data and set appropriate values.
+}
+
+/**
+ * Create a top-level collection with the given name.
+ * @param {String} collectionName The name of the top level collection to
+ * create.
+ * @param {firestore.Firestore} db The firestore instance.
+ * @returns {firestore.CollectionReference} The reference to the created
+ *  collection
+ */
+function createTopLevelCollection(collectionName, db) {
+  throw "NotImplementedError: Implement Me!";
+  // 1. Create collection
+
+  // 2. Add required data
+}
+
+/**
+ * Implements all required functionality.
+ *
+ * @param {firebase.firestore.Firestore} db The firestore instance.
+ */
+export function Run(db) {
+  const topLevelCollection = createTopLevelCollection(
+    TOP_LEVEL_COLLECTION_NAME,
+    db
+  );
+
+  const stepsCompletedCollection = createStepsCompletedCollection(
+    topLevelCollection
+  );
+
+  const researchItemsCollection = createResearchItemsCollection(
+    topLevelCollection,
+    stepsCompletedCollection
+  );
+
+  allAllResearchItems(researchItemsCollection, stepsCompletedCollection);
+}

--- a/test/ex01/unit.test.js
+++ b/test/ex01/unit.test.js
@@ -1,0 +1,104 @@
+/*
+ * Defines a simple unit tests using mocha and the firestore emulator.
+ */
+
+import { expect } from "chai";
+
+import {
+  initializeTestApp,
+  clearFirestoreData,
+  assertSucceeds,
+} from "@firebase/rules-unit-testing";
+import { firestore } from "firebase";
+
+import {
+  TOP_LEVEL_COLLECTION_NAME,
+  TEST_DOCUMENT_NAME,
+  COMPLETED_STEPS_DOC_NAME,
+  RESEARCH_ITEMS_COLLECTION_NAME,
+  PROJECT_ID,
+  FIRESTORE_EMULATOR_PORT,
+} from "./constants.js";
+
+// Add a statement with your solutions
+import { Run as solution } from "./solution";
+
+// And add it to the list of test suites.
+const testSuites = [{ name: "Solution", runImpl: solution }];
+
+/**
+ * Initializes a test instance of Firebase Firestore emulators.
+ *
+ * @returns {firestore.Firestore} The initialized firestore instance pointed at
+ * the Firestore emulator.
+ */
+function getFirestore() {
+  let db = initializeTestApp({ projectId: PROJECT_ID }).firestore();
+  db.useEmulator("localhost", FIRESTORE_EMULATOR_PORT);
+  return db;
+}
+
+function runTestSuites() {
+  testSuites.forEach((suiteDefinition) => {
+    describe(`Suite: ${suiteDefinition.name}: Unit Test`, function () {
+      // Run the specific suite with the given database.
+      const db = getFirestore();
+      suiteDefinition.runImpl(db);
+
+      // Actually check the results.
+      it(`should create a ${TOP_LEVEL_COLLECTION_NAME} document with required data items`, async function () {
+        const wantDocRef = db
+          .collection(TOP_LEVEL_COLLECTION_NAME)
+          .doc(TEST_DOCUMENT_NAME);
+        const doc = await wantDocRef.get();
+
+        expect(
+          doc.exists,
+          `Either the collection ("${TOP_LEVEL_COLLECTION_NAME}") or the document ("${TEST_DOCUMENT_NAME}") does not exist.`
+        ).to.be.equal(true);
+        expect(doc.get("authorName")).to.be.a("string", "authorName").that.is
+          .not.empty;
+      });
+
+      it(`should create a ${COMPLETED_STEPS_DOC_NAME} document`, async function () {
+        const wantDocRef = db
+          .collection(TOP_LEVEL_COLLECTION_NAME)
+          .doc(COMPLETED_STEPS_DOC_NAME);
+        const doc = await wantDocRef.get();
+        expect(
+          doc.exists,
+          `Either the collection ("${TOP_LEVEL_COLLECTION_NAME}") or the document ("${COMPLETED_STEPS_DOC_NAME}") does not exist.`
+        ).to.be.equal(true);
+
+        [
+          "createdATopLevelCollection",
+          "addADocumentInTopLevelCollection",
+          // TODO: Uncomment to validate these bools are set after implementing
+          // the remaining methods.
+          // "createdResearchItemsSubCollection",
+          // "addedAllResearchDocuments",
+        ].forEach((fieldName) => {
+          expect(doc.get(fieldName))
+            .to.be.a("boolean")
+            .that.is.equal(true, `${fieldName} should be true`);
+        });
+      });
+
+      it.skip(`should create a ${RESEARCH_ITEMS_COLLECTION_NAME} collection.`, async () => {});
+      it.skip(
+        `should create 9 research documents in the ${RESEARCH_ITEMS_COLLECTION_NAME} collection.`
+      );
+
+      // Teardown firestore test instance.
+      after(function (done) {
+        clearFirestoreData({
+          projectId: PROJECT_ID,
+        });
+
+        done();
+      });
+    });
+  });
+}
+
+runTestSuites();


### PR DESCRIPTION
1. Added a dependency on the `esm` module based on this article:

https://alxgbsn.co.uk/2019/02/22/testing-native-es-modules-mocha-esm/

Mocha interprets all files as CommonJS but the ES6 syntax is a bit
better to dev on. Since this test code doesn't run in a browser we don't
need to transpile it to CommonJS before shiping. Note: This is an area
of a lot of personal confusion despite reading much of the literature.
I think the consequence of this is that for testing js that runs in the
browswer we'll definitely need to stick to ES6 (and transpile to
a widely availabe ES5 before shipping). This all implies webpack or
Babel although I don't understand the implications fully.

2. All implemenations must export a Run() method which takes a db.
3. All implemenations must update the testSuites variable to register
   there implemenation.