### PR TITLE
Install OpenJDK 8 Runtime in Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
         curl \
         net-tools \
         apt-transport-https \
-        ca-certificates; 
+        ca-certificates \
+        openjdk-8-jre;
 
 EXPOSE 5000 5001 9005


### PR DESCRIPTION
This is required for firebase emulators. You'll need to rebase  the `homework` branch on mainline

```
git checkout mainline
git pull upstream mainline
git checkout homework
git rebase mainline
```

Rebuild the container.

This addresses #80 