### PR TITLE
Remove unnecessary imports in nav bar html.

### DIFF
--- a/public/templates/navBar.html
+++ b/public/templates/navBar.html
@@ -4,54 +4,15 @@
   name="viewport"
   content="width=device-width, initial-scale=1, shrink-to-fit=no"
 />
-<link
-rel="stylesheet"
-type="text/css"
-href="/assets/css/bootstrap.min.css"
-/>
-<link
-rel="stylesheet"
-type="text/css"
-href="/assets/css/font-awesome.css"
-/>
-<link
-rel="stylesheet"
-type="text/css"
-href="/assets/css/templatemo-art-factory.css"
-/>
-<link
-rel="stylesheet"
-type="text/css"
-href="/assets/css/owl-carousel.css"
-/>
-
-
-<!-- jQuery -->
-<script defer src="/assets/js/jquery-2.1.0.min.js"></script>
-
-<!-- jQuery -->
-<scrip defer src="https://code.jquery.com/jquery-3.5.1.js"></script>
-
-<!-- Bootstrap -->
-<script defer src="/assets/js/popper.js"></script>
-<script defer src="/assets/js/bootstrap.min.js"></script>
-
-<!-- Plugins -->
-<script defer src="/assets/js/owl-carousel.js"></script>
-<script defer src="/assets/js/scrollreveal.min.js"></script>
-<script defer src="/assets/js/waypoints.min.js"></script>
-<script defer src="/assets/js/jquery.counterup.min.js"></script>
-<script defer src="/assets/js/imgfix.min.js"></script>
-
-<!-- Global Init -->
-<script defer src="/assets/js/custom.js"></script>
 <header class="header-area header-sticky">
   <div class="container">
     <div class="row">
       <div class="col-12">
         <nav class="main-nav">
           <!-- ***** Logo Start ***** -->
-          <a href="/templates/index.html" class="logo scroll-to-section">Melly</a>
+          <a href="/templates/index.html" class="logo scroll-to-section"
+            >Melly</a
+          >
           <!-- ***** Logo End ***** -->
           <!-- ***** Menu Start ***** -->
           <ul class="nav">

--- a/public/templates/navBar.html
+++ b/public/templates/navBar.html
@@ -4,6 +4,13 @@
   name="viewport"
   content="width=device-width, initial-scale=1, shrink-to-fit=no"
 />
+<link rel="stylesheet" type="text/css" href="/assets/css/bootstrap.min.css" />
+<link rel="stylesheet" type="text/css" href="/assets/css/font-awesome.css" />
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="/assets/css/templatemo-art-factory.css"
+/>
 <header class="header-area header-sticky">
   <div class="container">
     <div class="row">


### PR DESCRIPTION
The site navigation works without these imports and having them
complicates the webpackification process.

Related to #99 